### PR TITLE
SLING-10960 switch to OSGI R7 annotations and update to sling-bundle-parent 46

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -148,7 +148,7 @@
                         <ClientSideTeleporter.testBundleDirectory>${project.build.directory}/test-bundles</ClientSideTeleporter.testBundleDirectory>
                         <ClientSideTeleporter.enableLogging>true</ClientSideTeleporter.enableLogging>
                         <!-- deploy test content and some Sling models with the test bundle -->
-                        <ClientSideTeleporter.additionalBundleHeaders>Sling-Initial-Content:SLING-CONTENT;overwrite:=true,Sling-Model-Packages:org.apache.sling.models.validation.impl.it</ClientSideTeleporter.additionalBundleHeaders>
+                        <ClientSideTeleporter.additionalBundleHeaders>Sling-Initial-Content:SLING-CONTENT/apps/sling/validation;overwrite:=true;path:=/apps/sling/validation,Sling-Model-Packages:org.apache.sling.models.validation.impl.it</ClientSideTeleporter.additionalBundleHeaders>
                         <ClientSideTeleporter.includeDependencyPrefixes>org.apache.sling.models.validation.impl.it</ClientSideTeleporter.includeDependencyPrefixes>
                     </systemPropertyVariables>
                 </configuration>
@@ -224,7 +224,7 @@
         <dependency>
             <groupId>org.apache.sling</groupId>
             <artifactId>org.apache.sling.junit.teleporter</artifactId>
-            <version>1.0.20</version>
+            <version>1.0.22</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.sling</groupId>
         <artifactId>sling-bundle-parent</artifactId>
-        <version>39</version>
+        <version>46</version>
         <relativePath />
     </parent>
 
@@ -159,6 +159,7 @@
         <dependency>
             <groupId>org.osgi</groupId>
             <artifactId>org.osgi.annotation.versioning</artifactId>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.sling</groupId>
@@ -175,13 +176,11 @@
         <dependency>
             <groupId>org.osgi</groupId>
             <artifactId>org.osgi.service.component.annotations</artifactId>
-            <version>1.3.0</version> <!-- downgrade to DS 1.3 (OSGi R6), as this leads to a run time dependency -->
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.osgi</groupId>
             <artifactId>org.osgi.service.metatype.annotations</artifactId>
-            <version>1.3.0</version> <!-- downgrade to metatype 1.3 (OSGi R6) -->
             <scope>provided</scope>
         </dependency>
         <dependency>
@@ -225,7 +224,12 @@
         <dependency>
             <groupId>org.apache.sling</groupId>
             <artifactId>org.apache.sling.junit.teleporter</artifactId>
-            <version>1.0.14</version>
+            <version>1.0.20</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.osgi</groupId>
+            <artifactId>org.osgi.framework</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/src/test/provisioning/model.txt
+++ b/src/test/provisioning/model.txt
@@ -16,7 +16,9 @@
 #  specific language governing permissions and limitations
 #  under the License.
 #
-[feature name=models.validation-impl.it]
+
+# features are ordered alphabetically, so make this feature the last one in order to overwrite configurations with same PIDs from other features
+[feature name=zzz.models.validation-impl.it]
 # Dependencies
 [artifacts]
   org.apache.sling/org.apache.sling.starter/11/slingstart
@@ -26,16 +28,11 @@
   org.apache.sling/org.apache.sling.models.validation-impl
 
 [configurations]
-  # configure service user mapping for validation framework
-  org.apache.sling.serviceusermapping.impl.ServiceUserMapperImpl.amended-validation
-    user.mapping=[ \
-    "org.apache.sling.validation.core\=sling-readall", \
-    ]
-    
+
   # configure service user mapping for junit core (being used in the IT itself)
   org.apache.sling.serviceusermapping.impl.ServiceUserMapperImpl.amended-junit
-    user.mapping=[ \
-    "org.apache.sling.junit.core\=sling-readall", \
+    user.mapping=[
+    "org.apache.sling.junit.core\=sling-readall"
     ]
 
 [settings]

--- a/src/test/provisioning/model.txt
+++ b/src/test/provisioning/model.txt
@@ -19,11 +19,11 @@
 [feature name=models.validation-impl.it]
 # Dependencies
 [artifacts]
-  org.apache.sling/org.apache.sling.launchpad/9/slingstart
+  org.apache.sling/org.apache.sling.starter/11/slingstart
   # this is necessary to execute the tests
-  org.apache.sling/org.apache.sling.junit.core/1.0.26
+  org.apache.sling/org.apache.sling.junit.core/1.0.28
   # deploy the to-be-tested bundle as well
-  org.apache.sling/org.apache.sling.models.validation-impl/1.0.0-SNAPSHOT
+  org.apache.sling/org.apache.sling.models.validation-impl
 
 [configurations]
   # configure service user mapping for validation framework


### PR DESCRIPTION
also update integration tests to Sling 11 to ensure they can be run with Java 8 and Java 11

@kwin the integration tests do not run successfully - i do not fully understand the reason. the testing bundle is deployed and the initial content contained in it is installed, but then the validation impl throws warnings like
```
01.12.2021 21:26:09.574 *WARN* [EventAdminThread #2] org.apache.sling.validation.impl.resourcemodel.ResourceValidationModelProviderImpl Could not get covered resource type of newly added validation model at /apps/sling/validation/models/model1
java.lang.IllegalStateException: Can no longer access resource at /apps/sling/validation/models/model1
	at org.apache.sling.validation.impl.resourcemodel.ResourceValidationModelProviderImpl.getResourceTypeOfValidationModel(ResourceValidationModelProviderImpl.java:199) [org.apache.sling.validation.core:1.0.4]
	at org.apache.sling.validation.impl.resourcemodel.ResourceValidationModelProviderImpl.handleEvent(ResourceValidationModelProviderImpl.java:163) [org.apache.sling.validation.core:1.0.4]
	at org.apache.felix.eventadmin.impl.handler.EventHandlerProxy.sendEvent(EventHandlerProxy.java:415)
	at org.apache.felix.eventadmin.impl.tasks.HandlerTask.run(HandlerTask.java:70) [org.apache.felix.eventadmin:1.5.0]
	at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:515)
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
	at java.base/java.lang.Thread.run(Thread.java:834)
```